### PR TITLE
Set nearest-neighbor EBSD resampling, and fix ntot calculation in texure.py

### DIFF
--- a/src/kanapy/ebsd_hex_grid.py
+++ b/src/kanapy/ebsd_hex_grid.py
@@ -162,7 +162,7 @@ def resample_quat_knn_markley(quat_src, idx, dist, p=2.0):
 def resample_ebsd_to_rect_grid(
     xy, phase, quat, iq,
     dx_out=None, dy_out=None, nx=None, ny=None, bounds=None,
-    k_phase=7, k_iq=7, k_quat=9,
+    k_phase=1, k_iq=1, k_quat=1,
     p_iq=2.0, p_quat=2.0
 ):
     """

--- a/src/kanapy/texture.py
+++ b/src/kanapy/texture.py
@@ -120,7 +120,9 @@ def merge_nodes(G, node1, node2):
     """
     # merge pixel lists of node 1 into node 2, delete node 1
     G.nodes[node2]['pixels'] = np.concatenate((G.nodes[node1]['pixels'], G.nodes[node2]['pixels']))
-    ntot = len(G.nodes)
+    npix1 = G.nodes[node1]['npix']
+    npix2 = G.nodes[node2]['npix']
+    ntot = npix1 + npix2
     G.nodes[node2]['ori_av'] = (G.nodes[node1]['ori_av'] * G.nodes[node1]['npix'] +
                                 G.nodes[node2]['ori_av'] * G.nodes[node2]['npix']) / ntot
     G.nodes[node2]['npix'] = ntot  # update length


### PR DESCRIPTION
1, The function resample_ebsd_to_rect_grid() in ebsd_hex_grid.py has the defaults parameters k_phase=7, k_iq=7, k_quat=9. I changed to k_phase=1, k_iq=1, k_quat=1. 

This makes the hex to rect resampling based on nearest neighbor, so each new pixel takes the value of the closest original EBSD point, instead of mixing several nearby points.


2, I also fixed one error in merge_nodes() in texure.py.
The original code used ntot = len(G.nodes), but that is the number of graph nodes, not the total number of pixels in the two merged grains. It should be:

**npix1 = G.nodes[node1]['npix']
npix2 = G.nodes[node2]['npix']
ntot = npix1 + npix2**

The merged grain size should be the sum of the two grain pixel counts, which is also needed for the correct weighted update of ori_av.